### PR TITLE
Surface area calculated 10x too big in kettle.py

### DIFF
--- a/kettle.py
+++ b/kettle.py
@@ -25,7 +25,7 @@ class Kettle(object):
         height = (volume * 1000) / (math.pi * math.pow(radius, 2))
 
         # surface in m^2
-        self._surface = (2 * math.pi * math.pow(radius, 2) + 2 * radius * height) / 1000
+        self._surface = (2 * math.pi * math.pow(radius, 2) + 2 * radius * height) / 10000
 
     @property
     def temperature(self):


### PR DESCRIPTION
100 cm in a meter so there are 100*100 cm^2 in a m^2, so divide by 10000 instead of 1000.

Surface area was calculated 10 times too big, resulting in way too high
heat loss through the kettle surface.